### PR TITLE
Add "u" to list of whitelisted tags.

### DIFF
--- a/changelog.markdown
+++ b/changelog.markdown
@@ -1,3 +1,6 @@
+
+- Add 'u' tag to accepted whitelist.
+
 # 2.5.1 Self-Filter
 
 - Filter works properly with self-closing tags

--- a/defaults.js
+++ b/defaults.js
@@ -12,7 +12,7 @@ var defaults = {
     'a', 'abbr', 'article', 'b', 'blockquote', 'br', 'caption', 'code', 'del', 'details', 'div', 'em',
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'ins', 'kbd', 'li', 'main', 'mark',
     'ol', 'p', 'pre', 'section', 'span', 'strike', 'strong', 'sub', 'summary', 'sup', 'table',
-    'tbody', 'td', 'th', 'thead', 'tr', 'ul'
+    'tbody', 'td', 'th', 'thead', 'tr', 'u', 'ul'
   ],
   filter: null
 };

--- a/readme.markdown
+++ b/readme.markdown
@@ -132,7 +132,7 @@ The default configuration is used if you don't provide any. This object is avail
     "a", "article", "b", "blockquote", "br", "caption", "code", "del", "details", "div", "em",
     "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i", "img", "ins", "kbd", "li", "main", "ol",
     "p", "pre", "section", "span", "strike", "strong", "sub", "summary", "sup", "table",
-    "tbody", "td", "th", "thead", "tr", "ul"
+    "tbody", "td", "th", "thead", "tr", "u", "ul"
   ],
   "filter": null,
   "transformText": null


### PR DESCRIPTION
The "u" tag is sometimes used for underlying and is not dangerous
according to Mozilla docs: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/u

Normally it's recommended to use another tag instead of "u", like using
<span> with CSS to style text with an underline.

However, this module does not allow the "style" element because CSS can
be dangerous, making the older "u" tag an interesting "safe" alternative
in this context.