### PR TITLE
Clarify override defaults a bit.

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -33,7 +33,7 @@ The parser takes into account that some elements can be self-closing. For safety
 
 ## `options`
 
-[Sensible defaults](#defaults) are provided, but you can change these options.
+[Sensible defaults](#defaults) are provided. You can override specific options as needed.
 
 #### `allowedSchemes`
 


### PR DESCRIPTION
"Change" could mean either "completely replace" or "override specific values".

Update wording to use "override" to make it clearer that the options
object provided doesn't replace the default options object, but
overrides specific values.