### PR TITLE
Create a catch-all ("*") rule for allowedAttributes

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -2,7 +2,8 @@
 
 var defaults = {
   allowedAttributes: {
-    a: ['href', 'name', 'target', 'title', 'aria-label'],
+    '*': ['title', 'accesskey'],
+    a: ['href', 'name', 'target', 'aria-label'],
     iframe: ['allowfullscreen', 'frameborder', 'src'],
     img: ['src', 'alt', 'title', 'aria-label']
   },

--- a/sanitizer.js
+++ b/sanitizer.js
@@ -44,6 +44,7 @@ function sanitizer (buffer, options) {
       var value = attrs[key];
       var classesOk = (o.allowedClasses || {})[low] || [];
       var attrsOk = (o.allowedAttributes || {})[low] || [];
+      attrsOk = attrsOk.concat((o.allowedAttributes || {})['*'] || []);
       var valid;
       var lkey = lowercase(key);
       if (lkey === 'class' && attrsOk.indexOf(lkey) === -1) {

--- a/test/insane.js
+++ b/test/insane.js
@@ -84,6 +84,15 @@ test('drops every attribute except the allowed ones, even in case of class names
   t.end();
 });
 
+test('succeeds because of catch-all allowedAttributes rules', function (t) {
+  t.equal(insane('<div a="nope" id="foo" class="bar baz" style="position:absolute">foo</div>', {
+    allowedTags: ['div'],
+    allowedAttributes: { '*': ['class', 'id', 'style'] } },
+    true
+  ), '<div id="foo" class="bar baz" style="position:absolute">foo</div>');
+  t.end();
+});
+
 test('drops every class name if not whitelisted', function (t) {
   t.equal(insane('<div a="a" b="b" class="foo bar">foo</div>', {
     allowedTags: ['div'],


### PR DESCRIPTION
Since some attributes are available on all tags (in e.g.: `title`, `style`, `id` etc), this PR provides a catch-all rule for allowedAttributes.