### PR TITLE
Adding tel: URL scheme for phone numbers in HTML

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -8,7 +8,7 @@ var defaults = {
     img: ['src', 'alt', 'title', 'aria-label']
   },
   allowedClasses: {},
-  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedSchemes: ['http', 'https', 'mailto','tel'],
   allowedTags: [
     'a', 'abbr', 'article', 'b', 'blockquote', 'br', 'caption', 'code', 'del', 'details', 'div', 'em',
     'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'ins', 'kbd', 'li', 'main', 'mark',


### PR DESCRIPTION
We can use the tel: URL scheme for phone numbers in HTML. Just like the mailto: URL scheme will open the default mail application. If the HTML page is viewed on a mobile phone and we select a link with the tel: scheme we can immediately call the number following the scheme. On a desktop computer, a VOIP call will be initiated.